### PR TITLE
Add tests and get working on RHEL

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,0 +1,11 @@
+- hosts: all
+  become: yes
+
+  tasks:
+    - debug:
+        msg: >-
+          Testing with Ansible {{ ansible_version.full }} using Python {{ ansible_facts.python_version }}
+          on {{ ansible_facts.distribution }} {{ ansible_facts.distribution_version }}
+
+    - import_role:
+        name: cockroachdb

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,26 @@
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  ansible-lint -x 204,301,305,403,502,503
+  yamllint -c molecule/default/yamllint.yml .
+platforms:
+  - name: cockroachdb-test-${MOLECULE_DISTRIBUTION:-centos8}
+    image: "quay.io/samdoran/${MOLECULE_DISTRIBUTION:-centos8}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: yes
+    pre_build_image: yes
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      stdout_callback: debug
+  playbooks:
+    converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+scenario:
+  name: default
+verifier:
+  name: ansible

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -1,0 +1,15 @@
+- name: Verify role
+  hosts: all
+  become: yes
+  gather_facts: no
+
+  vars_files:
+    - ../../defaults/main.yml
+
+  tasks:
+    - name: Check cluster initialization
+      shell: /usr/local/bin/cockroach sql --execute="SELECT 1" --user={{ roach_init_check_user }} --certs-dir={{ roach_init_cert_path }} --url postgresql://localhost
+      register: cluster_init_check
+      delegate_to: "{% if roach_pki_custom_ca %}localhost{% else %}{{ play_hosts[0] }}{% endif %}"
+      run_once: yes
+      ignore_errors: yes

--- a/molecule/default/yamllint.yml
+++ b/molecule/default/yamllint.yml
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  comments-indentation: disable
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -3,5 +3,5 @@
   apt:
     update_cache: no
     name:
-    - ntp
+      - ntp
     state: present

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -18,6 +18,7 @@
     path: /etc/ntp.conf
     state: absent
     regexp: '^([\s]*)(server|pool)'
+  notify: restart ntp
 
 - name: Add NTP servers
   blockinfile:
@@ -28,9 +29,6 @@
       server time3.google.com iburst
       server time4.google.com iburst
 
-- name: Restart NTP
-  systemd:
-    name: ntp
-    daemon_reload: yes
-    state: restarted
-    enabled: yes
+  notify: restart ntp
+
+- meta: flush_handlers

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -11,7 +11,7 @@
   shell: timedatectl set-ntp no
   ignore_errors: yes
   tags:
-    - ciskip
+    - notest
 
 - name: Remove NTP servers
   lineinfile:

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,7 +1,36 @@
 ---
 - name: Install required packages
   apt:
-    update_cache: no
+    update_cache: yes
     name:
       - ntp
     state: present
+
+# Setup NTP
+- name: Disable timesyncd
+  shell: timedatectl set-ntp no
+  ignore_errors: yes
+  tags:
+    - ciskip
+
+- name: Remove NTP servers
+  lineinfile:
+    path: /etc/ntp.conf
+    state: absent
+    regexp: '^([\s]*)(server|pool)'
+
+- name: Add NTP servers
+  blockinfile:
+    path: /etc/ntp.conf
+    block: |
+      server time1.google.com iburst
+      server time2.google.com iburst
+      server time3.google.com iburst
+      server time4.google.com iburst
+
+- name: Restart NTP
+  systemd:
+    name: ntp
+    daemon_reload: yes
+    state: restarted
+    enabled: yes

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -4,3 +4,11 @@
     name:
       - chrony
     state: present
+
+- name: Disable timesyncd
+  shell: timedatectl set-ntp no
+  ignore_errors: yes
+  tags:
+    - notest
+
+# configure chrony here

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -2,5 +2,5 @@
 - name: Install required packages
   package:
     name:
-    - ntp
+      - ntp
     state: present

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -2,5 +2,5 @@
 - name: Install required packages
   package:
     name:
-      - ntp
+      - chrony
     state: present

--- a/tasks/install-RedHat.yml
+++ b/tasks/install-RedHat.yml
@@ -11,4 +11,31 @@
   tags:
     - notest
 
-# configure chrony here
+- name: Remove time servers
+  lineinfile:
+    path: /etc/chrony.conf
+    state: absent
+    regexp: '^([\s]*)(server|pool)'
+  notify: restart chrony
+
+- name: Create chrony.d
+  file:
+    path: /etc/chrony.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Include config files
+  lineinfile:
+    path: /etc/chrony.conf
+    line: include /etc/chrony.d/*.conf
+  notify: restart chrony
+
+- name: Add time servers
+  template:
+    src: google.conf
+    dest: /etc/chrony.d/google.conf
+  notify: restart chrony
+
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,8 +37,8 @@
 
 - name: Download cockroach binary
   get_url:
-      url: "https://binaries.cockroachdb.com/cockroach-{{ roach_version }}.linux-amd64.tgz"
-      dest: "{{ cockroach_temp.path }}/cockroach.tgz"
+    url: "https://binaries.cockroachdb.com/cockroach-{{ roach_version }}.linux-amd64.tgz"
+    dest: "{{ cockroach_temp.path }}/cockroach.tgz"
   register: dl_cockroach
 
 - name: Create temporary directory to extract cockroach
@@ -83,134 +83,133 @@
 
 # PKI
 - name: Setup PKI
+  when: not roach_pki_custom_ca
   block:
   # Simple PKI with `cockroach certs`
 
-  # This path `roach_pki_path` is for the simple PKI only
-  - name: Create PKI directories
-    file:
-      path: "{{ roach_pki_path }}"
-      state: directory
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
+    # This path `roach_pki_path` is for the simple PKI only
+    - name: Create PKI directories
+      file:
+        path: "{{ roach_pki_path }}"
+        state: directory
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
 
-  - name: Check CA file on first node
-    stat:
-      path: "{{ roach_pki_path }}/ca.key"
-    register: ca_key_stat
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
+    - name: Check CA file on first node
+      stat:
+        path: "{{ roach_pki_path }}/ca.key"
+      register: ca_key_stat
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
 
-  - name: Create CA cert
-    shell: "cockroach cert create-ca --certs-dir={{ roach_pki_path }} --ca-key={{ roach_pki_path }}/ca.key"
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
-    when:
-      - not ca_key_stat.stat.exists
+    - name: Create CA cert
+      shell: "cockroach cert create-ca --certs-dir={{ roach_pki_path }} --ca-key={{ roach_pki_path }}/ca.key"
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
+      when:
+        - not ca_key_stat.stat.exists
 
-  - name: Check cert file for node
-    stat:
-      path: "{{ roach_pki_path }}/node-{{ ansible_facts['hostname'] }}.key"
-    register: node_key_stat
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
+    - name: Check cert file for node
+      stat:
+        path: "{{ roach_pki_path }}/node-{{ ansible_facts['hostname'] }}.key"
+      register: node_key_stat
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
 
-  # This is ugly but ended up being the simplest way with how cockroach works
-  # and not requing the localhost to be the CA
-  - name: Create node certs
-    shell: |
-      {% for host in play_hosts %}
-      cockroach cert create-node \
-      {{ hostvars[host]['ansible_all_ipv4_addresses'] | join(' ') }} \
-      {{ hostvars[host]['ansible_facts']['fqdn'] }} \
-      {{ hostvars[host]['ansible_facts']['hostname'] }} \
-      localhost 127.0.0.1 \
-      --certs-dir={{ roach_pki_path }} \
-      --ca-key={{ roach_pki_path }}/ca.key && \
-      mv {{ roach_pki_path }}/node.crt {{ roach_pki_path }}/node-{{ hostvars[host]['ansible_facts']['hostname'] }}.crt && \
-      mv {{ roach_pki_path }}/node.key {{ roach_pki_path }}/node-{{ hostvars[host]['ansible_facts']['hostname'] }}.key
-      {% endfor %}
+    # This is ugly but ended up being the simplest way with how cockroach works
+    # and not requing the localhost to be the CA
+    - name: Create node certs
+      shell: |
+        {% for host in play_hosts %}
+        cockroach cert create-node \
+        {{ hostvars[host]['ansible_all_ipv4_addresses'] | join(' ') }} \
+        {{ hostvars[host]['ansible_facts']['fqdn'] }} \
+        {{ hostvars[host]['ansible_facts']['hostname'] }} \
+        localhost 127.0.0.1 \
+        --certs-dir={{ roach_pki_path }} \
+        --ca-key={{ roach_pki_path }}/ca.key && \
+        mv {{ roach_pki_path }}/node.crt {{ roach_pki_path }}/node-{{ hostvars[host]['ansible_facts']['hostname'] }}.crt && \
+        mv {{ roach_pki_path }}/node.key {{ roach_pki_path }}/node-{{ hostvars[host]['ansible_facts']['hostname'] }}.key
+        {% endfor %}
 
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
-    when:
-      - not node_key_stat.stat.exists
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
+      when:
+        - not node_key_stat.stat.exists
 
-#  # This is probably a bug that cockroach doesn't do this
-#  - name: Secure private keys
-#    file:
-#      path: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.key"
-#      mode: '0600'
-#    delegate_to: "{{ play_hosts[0] }}"
+  #  # This is probably a bug that cockroach doesn't do this
+  #  - name: Secure private keys
+  #    file:
+  #      path: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.key"
+  #      mode: '0600'
+  #    delegate_to: "{{ play_hosts[0] }}"
 
-  - name: Read CA cert file
-    slurp:
-      src: "{{ roach_pki_path }}/ca.crt"
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
-    register: ca_cert
+    - name: Read CA cert file
+      slurp:
+        src: "{{ roach_pki_path }}/ca.crt"
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
+      register: ca_cert
 
-  - name: Read node cert file
-    slurp:
-      src: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.crt"
-    delegate_to: "{{ play_hosts[0] }}"
-    register: node_cert
+    - name: Read node cert file
+      slurp:
+        src: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.crt"
+      delegate_to: "{{ play_hosts[0] }}"
+      register: node_cert
 
-  - name: Read node key file
-    slurp:
-      src: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.key"
-    delegate_to: "{{ play_hosts[0] }}"
-    register: node_key
+    - name: Read node key file
+      slurp:
+        src: "{{ roach_pki_path }}/node-{{ ansible_hostname }}.key"
+      delegate_to: "{{ play_hosts[0] }}"
+      register: node_key
 
-  - name: Install cert files
-    copy:
-      dest: "{{ roach_path ~ '/certs/' ~ item.file }}"
-      content: "{{ item.content | b64decode }}"
-      mode: "{{ item.mode }}"
-    with_items:
-      - file: ca.crt
-        content: "{{ ca_cert.content }}"
-        mode: '0644'
-      - file: node.crt
-        content: "{{ node_cert.content }}"
-        mode: '0644'
-      - file: node.key
-        content: "{{ node_key.content }}"
-        mode: '0600'
+    - name: Install cert files
+      copy:
+        dest: "{{ roach_path ~ '/certs/' ~ item.file }}"
+        content: "{{ item.content | b64decode }}"
+        mode: "{{ item.mode }}"
+      with_items:
+        - file: ca.crt
+          content: "{{ ca_cert.content }}"
+          mode: '0644'
+        - file: node.crt
+          content: "{{ node_cert.content }}"
+          mode: '0644'
+        - file: node.key
+          content: "{{ node_key.content }}"
+          mode: '0600'
 
-  # From here on, switch to the roach_path because cockroach is too opinionated
-  # about its diretory and doesn't like other cert filenames
-  - name: Check cert file for client
-    stat:
-      path: "{{ roach_path }}/certs/client.root.key"
-    register: client_key_stat
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
+    # From here on, switch to the roach_path because cockroach is too opinionated
+    # about its diretory and doesn't like other cert filenames
+    - name: Check cert file for client
+      stat:
+        path: "{{ roach_path }}/certs/client.root.key"
+      register: client_key_stat
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
 
-  - name: Create client cert
-    shell: |
-      cockroach cert create-client root --certs-dir={{ roach_path }}/certs --ca-key={{ roach_pki_path }}/ca.key
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
-    when:
-      - not client_key_stat.stat.exists
+    - name: Create client cert
+      shell: |
+        cockroach cert create-client root --certs-dir={{ roach_path }}/certs --ca-key={{ roach_pki_path }}/ca.key
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
+      when:
+        - not client_key_stat.stat.exists
 
-  - name: Install client cert files
-    fetch:
-      src: "{{ roach_path ~ '/certs/' ~ item.file }}"
-      dest: "{{ lookup('env','HOME') ~ '/' ~ item.file }}"
-      mode: "{{ item.mode }}"
-    with_items:
-      - file: ca.crt
-        mode: '0644'
-      - file: client.root.crt
-        mode: '0644'
-      - file: client.root.key
-        mode: '0600'
-    delegate_to: "{{ play_hosts[0] }}"
-    run_once: yes
-  when:
-    - not roach_pki_custom_ca
+    - name: Install client cert files
+      fetch:
+        src: "{{ roach_path ~ '/certs/' ~ item.file }}"
+        dest: "{{ lookup('env','HOME') ~ '/' ~ item.file }}"
+        mode: "{{ item.mode }}"
+      with_items:
+        - file: ca.crt
+          mode: '0644'
+        - file: client.root.crt
+          mode: '0644'
+        - file: client.root.key
+          mode: '0600'
+      delegate_to: "{{ play_hosts[0] }}"
+      run_once: yes
 
 - name: Set ownership on cockroach directories
   file:
@@ -226,7 +225,7 @@
       {% for host in play_hosts[:-1] %}{{ hostvars[host]['ansible_default_ipv4']['address'] ~ ',' }}{% endfor %}{{ hostvars[play_hosts[-1]]['ansible_default_ipv4']['address'] }}
   template:
     src: cockroach.service.j2
-    dest: "{{roach_systemd_path}}/cockroachdb.service"
+    dest: "{{ roach_systemd_path }}/cockroachdb.service"
   register: roach_systemd_unit
 
 - name: Restart cockroachdb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
   copy:
     src: "{{ cockroach_extract_temp.path }}/cockroach-{{ roach_version }}.linux-amd64/cockroach"
     dest: /usr/local/bin/cockroach
-    mode: 0755
+    mode: '0755'
     remote_src: yes
 
 - name: Create cockroach group

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,33 +1,6 @@
 ---
 - include_tasks: "install-{{ ansible_facts.os_family }}.yml"
 
-# Setup NTP
-- name: Disable timesyncd
-  shell: timedatectl set-ntp no
-  ignore_errors: yes
-
-- name: Remove NTP servers
-  lineinfile:
-    path: /etc/ntp.conf
-    state: absent
-    regexp: '^([\s]*)(server|pool)'
-
-- name: Add NTP servers
-  blockinfile:
-    path: /etc/ntp.conf
-    block: |
-      server time1.google.com iburst
-      server time2.google.com iburst
-      server time3.google.com iburst
-      server time4.google.com iburst
-
-- name: Restart NTP
-  systemd:
-    name: ntp
-    daemon_reload: yes
-    state: restarted
-    enabled: yes
-
 # Download the cockroach binary
 - name: Create temporary directory for cockroach
   tempfile:
@@ -103,7 +76,7 @@
       run_once: yes
 
     - name: Create CA cert
-      shell: "cockroach cert create-ca --certs-dir={{ roach_pki_path }} --ca-key={{ roach_pki_path }}/ca.key"
+      shell: "/usr/local/bin/cockroach cert create-ca --certs-dir={{ roach_pki_path }} --ca-key={{ roach_pki_path }}/ca.key"
       delegate_to: "{{ play_hosts[0] }}"
       run_once: yes
       when:
@@ -121,7 +94,7 @@
     - name: Create node certs
       shell: |
         {% for host in play_hosts %}
-        cockroach cert create-node \
+        /usr/local/bin/cockroach cert create-node \
         {{ hostvars[host]['ansible_all_ipv4_addresses'] | join(' ') }} \
         {{ hostvars[host]['ansible_facts']['fqdn'] }} \
         {{ hostvars[host]['ansible_facts']['hostname'] }} \
@@ -190,7 +163,7 @@
 
     - name: Create client cert
       shell: |
-        cockroach cert create-client root --certs-dir={{ roach_path }}/certs --ca-key={{ roach_pki_path }}/ca.key
+        /usr/local/bin/cockroach cert create-client root --certs-dir={{ roach_path }}/certs --ca-key={{ roach_pki_path }}/ca.key
       delegate_to: "{{ play_hosts[0] }}"
       run_once: yes
       when:
@@ -256,7 +229,7 @@
 
 # This expects the user client cert to be on the host
 - name: Check cluster initialization
-  shell: cockroach sql --execute="SELECT 1" --user={{ roach_init_check_user }} --certs-dir={{ roach_init_cert_path }} --url postgresql://localhost
+  shell: /usr/local/bin/cockroach sql --execute="SELECT 1" --user={{ roach_init_check_user }} --certs-dir={{ roach_init_cert_path }} --url postgresql://localhost
   register: cluster_init_check
   delegate_to: "{% if roach_pki_custom_ca %}localhost{% else %}{{ play_hosts[0] }}{% endif %}"
   run_once: yes

--- a/templates/google.conf
+++ b/templates/google.conf
@@ -1,0 +1,4 @@
+server time1.google.com iburst
+server time2.google.com iburst
+server time3.google.com iburst
+server time4.google.com iburst


### PR DESCRIPTION
Add tests using `molecule`. Made changes to get it working with Debian 10 and CentOS 8 and fix some linting issues.

Run tests with `molecule test`.

To keep the image around for repeated testing, run `molecule converge`.

To just into the container, run `molecule login`.

The role reports changes every time, so it will fail `molecule idempotence`.

When done, run `molecule destroy`.

To test with other distributions, use the `MOLECULE_DISTRIBUTION` variable.

```
MOLECULE_DISTRIBUTION=debian10 molecule converge
```